### PR TITLE
Decouple collector and executor

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -27,10 +27,13 @@ type collector[T any] struct {
 	executor Executor
 	out      []T
 	mu       sync.Mutex
+	wg       sync.WaitGroup
 }
 
 func (c *collector[T]) Provide(provider ProviderFunc[T]) {
+	c.wg.Add(1)
 	c.executor.Execute(func() {
+		defer c.wg.Done()
 		values := provider()
 		c.mu.Lock()
 		c.out = append(c.out, values)
@@ -39,7 +42,7 @@ func (c *collector[T]) Provide(provider ProviderFunc[T]) {
 }
 
 func (c *collector[T]) Collect() (everything []T) {
-	c.executor.Wait()
+	c.wg.Wait()
 	c.mu.Lock()
 	everything = c.out
 	c.out = nil


### PR DESCRIPTION
This allows for long-lived executors and many short-lived collectors to exist.