### PR TITLE
Add context helpers

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,17 @@
+package sync
+
+import "context"
+
+type executorKey struct{}
+
+func ContextExecutor(ctx context.Context) Executor {
+	executor, ok := ctx.Value(executorKey{}).(Executor)
+	if !ok {
+		return sequentialExecutor{}
+	}
+	return executor
+}
+
+func SetContextExecutor(ctx context.Context, executor Executor) context.Context {
+	return context.WithValue(ctx, executorKey{}, executor)
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,29 @@
+package sync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextExecutor(t *testing.T) {
+	t.Run("WithExecutorInContext", func(t *testing.T) {
+		executor := NewExecutor(1)
+		ctx := SetContextExecutor(context.Background(), executor)
+
+		result := ContextExecutor(ctx)
+
+		require.NotNil(t, result)
+		require.IsType(t, &boundedExecutor{}, result)
+	})
+
+	t.Run("WithoutExecutorInContext", func(t *testing.T) {
+		ctx := context.Background()
+
+		result := ContextExecutor(ctx)
+
+		require.NotNil(t, result)
+		require.IsType(t, sequentialExecutor{}, result)
+	})
+}


### PR DESCRIPTION
This allows folks across library boundaries to safely interact with executors without having to worry about the context access concerns.
