### PR TITLE
Parallel `Collect` & `io.Writer`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
+    - copyloopvar
     - funlen
     - gocognit
     - goconst
@@ -49,8 +49,8 @@ linters-settings:
     # If lower than 0, disable the check.
     # Default: 40
     statements: 80
-output:
-  uniq-by-line: false
+    issues:
+      uniq-by-line: false
 run:
   timeout: 10m
 

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ LINT_CMD = $(TEMP_DIR)/golangci-lint run --tests=false --config .golangci.yaml
 GOIMPORTS_CMD := $(TEMP_DIR)/gosimports -local github.com/anchore
 
 # Tool versions #################################
-GOLANGCILINT_VERSION := v1.56.0
+GOLANGCILINT_VERSION := v1.63.4
 GOSIMPORTS_VERSION := v0.3.8
 BOUNCER_VERSION := v0.4.0
-CHRONICLE_VERSION := v0.6.0
+CHRONICLE_VERSION := v0.8.0
 
 # Formatting variables #################################
 BOLD := $(shell tput -T linux bold)

--- a/collector.go
+++ b/collector.go
@@ -14,7 +14,7 @@ func Collect[From, To any](ctx context.Context, executorName string, values iter
 	var errs []error
 	var lock sync.Mutex
 	var wg sync.WaitGroup
-	executor := GetExecutor(&ctx, executorName)
+	executor := GetExecutor(ctx, executorName)
 	for value := range values {
 		wg.Add(1)
 		executor.Execute(ctx, func(ctx context.Context) {

--- a/collector.go
+++ b/collector.go
@@ -10,40 +10,59 @@ import (
 // Collect iterates over the provided values, executing the processor in parallel to map each incoming value to a result.
 // The collector is used to apply the results, with an exclusive lock; collector will never execute in parallel.
 // All errors returned from processor functions will be joined with errors.Join as the returned error.
-func Collect[From, To any](ctx context.Context, executorName string, values iter.Seq[From], collector func(context.Context, From, To), processor func(context.Context, From) (To, error)) error {
+func Collect[From, To any](ctx *context.Context, executorName string, values iter.Seq[From], collector func(From, To), processor func(From) (To, error)) error {
 	var errs []error
 	var lock sync.Mutex
 	var wg sync.WaitGroup
-	executor := GetExecutor(ctx, executorName)
+	executor := ContextExecutor(ctx, executorName)
 	for value := range values {
+		// skip queuing any more values
+		if (*ctx).Err() != nil {
+			break
+		}
 		wg.Add(1)
-		executor.Execute(ctx, func(ctx context.Context) {
+		executor.Execute(func() {
 			defer wg.Done()
-			result, err := processor(ctx, value)
+			// we may have queued many functions when canceled
+			if (*ctx).Err() != nil {
+				return
+			}
+			result, err := processor(value)
 			lock.Lock()
 			defer lock.Unlock()
 			if err != nil {
 				errs = append(errs, err)
 			}
 			if collector != nil {
-				collector(ctx, value, result)
+				collector(value, result)
 			}
 		})
 	}
-	wg.Wait()
+
+	done := make(chan struct{}, 1)
+	go func() {
+		wg.Wait()
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-(*ctx).Done():
+	case <-done:
+	}
+
 	return errors.Join(errs...)
 }
 
 // CollectSlice is a specialized Collect call which appends results to a slice
-func CollectSlice[From, To any](ctx context.Context, executorName string, values iter.Seq[From], slice *[]To, processor func(context.Context, From) (To, error)) error {
-	return Collect(ctx, executorName, values, func(_ context.Context, _ From, value To) {
+func CollectSlice[From, To any](ctx *context.Context, executorName string, values iter.Seq[From], slice *[]To, processor func(From) (To, error)) error {
+	return Collect(ctx, executorName, values, func(_ From, value To) {
 		*slice = append(*slice, value)
 	}, processor)
 }
 
 // CollectMap is a specialized Collect call which fills a map using the incoming value as a key, mapped to the result
-func CollectMap[From comparable, To any](ctx context.Context, executorName string, values iter.Seq[From], result map[From]To, processor func(context.Context, From) (To, error)) error {
-	return Collect(ctx, executorName, values, func(_ context.Context, key From, value To) {
+func CollectMap[From comparable, To any](ctx *context.Context, executorName string, values iter.Seq[From], result map[From]To, processor func(From) (To, error)) error {
+	return Collect(ctx, executorName, values, func(key From, value To) {
 		result[key] = value
 	}, processor)
 }

--- a/collector.go
+++ b/collector.go
@@ -36,14 +36,14 @@ func Collect[From, To any](ctx context.Context, executorName string, values iter
 
 // CollectSlice is a specialized Collect call which appends results to a slice
 func CollectSlice[From, To any](ctx context.Context, executorName string, values iter.Seq[From], slice *[]To, processor func(context.Context, From) (To, error)) error {
-	return Collect(ctx, executorName, values, func(ctx context.Context, _ From, value To) {
+	return Collect(ctx, executorName, values, func(_ context.Context, _ From, value To) {
 		*slice = append(*slice, value)
 	}, processor)
 }
 
 // CollectMap is a specialized Collect call which fills a map using the incoming value as a key, mapped to the result
 func CollectMap[From comparable, To any](ctx context.Context, executorName string, values iter.Seq[From], result map[From]To, processor func(context.Context, From) (To, error)) error {
-	return Collect(ctx, executorName, values, func(ctx context.Context, key From, value To) {
+	return Collect(ctx, executorName, values, func(_ context.Context, key From, value To) {
 		result[key] = value
 	}, processor)
 }

--- a/collector.go
+++ b/collector.go
@@ -27,7 +27,7 @@ func Collect[From, To any](ctx *context.Context, executorName string, iterator i
 			break
 		}
 		wg.Add(1)
-		executor.Execute(func() {
+		executor.Go(func() {
 			defer wg.Done()
 			// we may have queued many functions when canceled
 			if (*ctx).Err() != nil {

--- a/collector_test.go
+++ b/collector_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"iter"
 	"testing"
 	"time"
@@ -18,7 +19,8 @@ func Test_ReduceCollectSlice(t *testing.T) {
 	concurrency := stats.Tracked[int]{}
 
 	var values []int
-	err := CollectSlice(e, countIter(count), &values, func(i int) (int, error) {
+	ctx := SetContextExecutor(context.TODO(), "", e)
+	err := CollectSlice(ctx, "", countIter(count), &values, func(ctx context.Context, i int) (int, error) {
 		defer concurrency.Incr()()
 
 		time.Sleep(1 * time.Millisecond)
@@ -43,7 +45,8 @@ func Test_ReduceCollectMap(t *testing.T) {
 	concurrency := stats.Tracked[int]{}
 
 	values := map[int]int{}
-	err := CollectMap(e, countIter(count), values, func(i int) (int, error) {
+	ctx := SetContextExecutor(context.TODO(), "", e)
+	err := CollectMap(ctx, "", countIter(count), values, func(ctx context.Context, i int) (int, error) {
 		defer concurrency.Incr()()
 
 		time.Sleep(1 * time.Millisecond)

--- a/collector_test.go
+++ b/collector_test.go
@@ -1,279 +1,81 @@
 package sync
 
 import (
-	"sync"
-	"sync/atomic"
+	"iter"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/go-sync/internal/stats"
 )
 
-func Test_Collectors(t *testing.T) {
-	for i := 0; i < 100; i++ {
-		Test_Collector(t)
-	}
-}
-
-func Test_Collector(t *testing.T) {
-	const count = 20
+func Test_ReduceCollectSlice(t *testing.T) {
+	const count = 1000
 	const maxConcurrency = 5
-	c := NewCollector[int](NewExecutor(maxConcurrency))
+	e := NewExecutor(maxConcurrency)
 
 	concurrency := stats.Tracked[int]{}
 
-	for i := 0; i < count; i++ {
-		i := i
-		c.Provide(func() int {
-			defer concurrency.Incr()()
+	var values []int
+	err := CollectSlice(e, countIter(count), &values, func(i int) (int, error) {
+		defer concurrency.Incr()()
 
-			time.Sleep(1 * time.Millisecond)
+		time.Sleep(1 * time.Millisecond)
 
-			return i
-		})
-	}
+		return i * 10, nil
+	})
+	require.NoError(t, err)
 
-	values := c.Collect()
 	require.Len(t, values, count)
 	for i := 0; i < count; i++ {
-		require.Contains(t, values, i)
+		require.Contains(t, values, i*10)
 	}
 
 	require.LessOrEqual(t, concurrency.Max(), maxConcurrency)
 }
 
-func Test_lotsaLotsaCollector(t *testing.T) {
-	concurrency := 100
-	executors := 1000
+func Test_ReduceCollectMap(t *testing.T) {
+	const count = 1000
+	const maxConcurrency = 5
+	e := NewExecutor(maxConcurrency)
 
-	concurrent := stats.Tracked[int64]{}
+	concurrency := stats.Tracked[int]{}
 
-	c := NewCollector[int](NewExecutor(concurrency))
-	for i := 0; i < executors; i++ {
-		i := i
-		c.Provide(func() int {
-			defer concurrent.Incr()()
-			Test_collector(t)
-			return i
-		})
-	}
+	values := map[int]int{}
+	err := CollectMap(e, countIter(count), values, func(i int) (int, error) {
+		defer concurrency.Incr()()
 
-	got := c.Collect()
-	require.Len(t, got, executors)
-	t.Logf("max concurrent: %d", concurrent.Max())
-}
+		time.Sleep(1 * time.Millisecond)
 
-func Test_lotsaCollector(t *testing.T) {
-	for i := 0; i < 1000; i++ {
-		Test_collector(t)
-	}
-}
+		return i * 10, nil
+	})
+	require.NoError(t, err)
 
-func Test_collector(t *testing.T) {
-	concurrency := (25)
-	count := 1000
-
-	wgs := make([]sync.WaitGroup, count)
-
-	concurrent := stats.Tracked[int64]{}
-	total := atomic.Uint64{}
-
-	makeFunc := func(idx int) func() int {
-		wgs[idx].Add(1)
-		return func() int {
-			defer total.Add(1)
-			concurrent.Incr()
-			wgs[idx].Wait()
-			concurrent.Decr()
-			return idx
-		}
-	}
-
-	var expected []int
-
-	c := NewCollector[int](NewExecutor(concurrency))
+	require.Len(t, values, count)
 	for i := 0; i < count; i++ {
-		expected = append(expected, i)
-		c.Provide(makeFunc(i))
+		require.Equal(t, values[i], i*10)
 	}
 
-	go func() {
-		for i := 0; i < count; i++ {
-			wgs[i].Done()
-		}
-	}()
-
-	got := c.Collect()
-	require.ElementsMatch(t, expected, got)
-
-	require.LessOrEqual(t, concurrent.Max(), int64(concurrency))
-	require.Equal(t, total.Load(), uint64(count))
+	require.LessOrEqual(t, concurrency.Max(), maxConcurrency)
 }
 
-func Test_collectorSmall(t *testing.T) {
-	concurrency := (2)
-	count := 4
+func Test_ToSeqToSlice(t *testing.T) {
+	expected := []int{0, 1, 2, 3, 4}
 
-	wgs := make([]sync.WaitGroup, count)
-	waiting := sync.WaitGroup{}
-	waiting.Add(int(concurrency))
+	seq := ToSeq(expected)
 
-	concurrent := stats.Tracked[int]{}
-	total := atomic.Uint64{}
+	got := ToSlice(seq)
 
-	makeFunc := func(idx int) func() int {
-		wgs[idx].Add(1)
-		return func() int {
-			if idx < int(concurrency) {
-				waiting.Done()
+	require.EqualValues(t, expected, got)
+}
+
+func countIter(count int) iter.Seq[int] {
+	return func(yield func(int) bool) {
+		for i := 0; i < count; i++ {
+			if !yield(i) {
+				return
 			}
-			defer total.Add(1)
-			concurrent.Incr()
-			wgs[idx].Wait()
-			concurrent.Decr()
-			return idx
 		}
 	}
-
-	var expected []int
-
-	c := NewCollector[int](NewExecutor(concurrency))
-	for i := 0; i < count; i++ {
-		expected = append(expected, i)
-		c.Provide(makeFunc(i))
-	}
-
-	time.Sleep(10 * time.Millisecond)
-	waiting.Wait()
-	require.Equal(t, 2, concurrent.Val())
-
-	go func() {
-		for i := 0; i < count; i++ {
-			wgs[i].Done()
-		}
-	}()
-
-	got := c.Collect()
-	require.ElementsMatch(t, expected, got)
-
-	require.LessOrEqual(t, concurrent.Max(), concurrency)
-	require.Equal(t, total.Load(), uint64(count))
-}
-
-func Test_collectorLimiting(t *testing.T) {
-	c := NewCollector[string](NewExecutor(2))
-
-	wg1 := &sync.WaitGroup{}
-	wg1.Add(1)
-	wg2 := &sync.WaitGroup{}
-	wg2.Add(1)
-	wg3 := &sync.WaitGroup{}
-	wg3.Add(1)
-
-	order := List[string]{}
-	executed := ""
-
-	wgReady := &sync.WaitGroup{}
-	wgReady.Add(2)
-
-	c.Provide(func() string {
-		order.Add("pre wg1")
-		wgReady.Done()
-		wg1.Wait()
-		order.Add("post wg1")
-		executed += "1_"
-		return "1"
-	})
-
-	c.Provide(func() string {
-		order.Add("pre wg2")
-		wgReady.Done()
-		wg2.Wait()
-		order.Add("post wg2")
-		executed += "2_"
-		wg3.Done()
-		return "2"
-	})
-
-	wgReady.Wait()
-
-	c.Provide(func() string {
-		order.Add("pre wg3")
-		wg3.Wait()
-		order.Add("post wg3")
-		executed += "3_"
-		wg1.Done()
-		return "3"
-	})
-
-	wg2.Done()
-
-	got := c.Collect()
-	require.Equal(t, "2_3_1_", executed)
-	require.ElementsMatch(t, []string{"2", "3", "1"}, got)
-	require.True(t,
-		order.indexOf("post wg2") < order.indexOf("post wg3") &&
-			order.indexOf("post wg3") < order.indexOf("post wg1"),
-	)
-}
-
-func Test_collectorDecoupledFromExecutor(t *testing.T) {
-	// this test shows that the executor and collector are loosely coupled -- a collector
-	// does not depend on the lifetime of the executor given to it.
-	exec := NewExecutor(2)
-	c := NewCollector[string](exec)
-
-	wg1 := &sync.WaitGroup{}
-	wg1.Add(1)
-	wg2 := &sync.WaitGroup{}
-	wg2.Add(1)
-	wg3 := &sync.WaitGroup{}
-	wg3.Add(1)
-
-	executed := ""
-
-	wgReady := &sync.WaitGroup{}
-	wgReady.Add(2)
-
-	c.Provide(func() string {
-		wgReady.Done()
-		executed += "1_"
-		wg1.Done()
-		return "1"
-	})
-
-	exec.Execute(func() {
-		wg3.Wait()
-		executed += "1e_"
-	})
-
-	c.Provide(func() string {
-		wgReady.Done()
-		wg1.Wait()
-		executed += "2_"
-		wg2.Done()
-		return "2"
-	})
-
-	wgReady.Wait()
-
-	c.Provide(func() string {
-		executed += "3_"
-		return "3"
-	})
-
-	// the key to this test is here: since "1e_" is not part of the collector, it will not be waited on. If we
-	// did accidentally wait on it, the test would hang here.
-	got := c.Collect()
-
-	assert.Equal(t, []string{"1", "2", "3"}, got)
-
-	wg3.Done()
-
-	exec.Wait()
-
-	require.Equal(t, "1_2_3_1e_", executed)
 }

--- a/collector_test.go
+++ b/collector_test.go
@@ -14,12 +14,12 @@ import (
 func Test_ReduceCollectSlice(t *testing.T) {
 	const count = 1000
 	const maxConcurrency = 5
-	e := NewExecutor(maxConcurrency)
+	e := NewExecutor("", maxConcurrency)
 
 	concurrency := stats.Tracked[int]{}
 
 	var values []int
-	ctx := SetContextExecutor(context.TODO(), "", e)
+	ctx := SetContextExecutor(context.TODO(), e)
 	err := CollectSlice(ctx, "", countIter(count), &values, func(ctx context.Context, i int) (int, error) {
 		defer concurrency.Incr()()
 
@@ -40,12 +40,12 @@ func Test_ReduceCollectSlice(t *testing.T) {
 func Test_ReduceCollectMap(t *testing.T) {
 	const count = 1000
 	const maxConcurrency = 5
-	e := NewExecutor(maxConcurrency)
+	e := NewExecutor("", maxConcurrency)
 
 	concurrency := stats.Tracked[int]{}
 
 	values := map[int]int{}
-	ctx := SetContextExecutor(context.TODO(), "", e)
+	ctx := SetContextExecutor(context.TODO(), e)
 	err := CollectMap(ctx, "", countIter(count), values, func(ctx context.Context, i int) (int, error) {
 		defer concurrency.Incr()()
 

--- a/context.go
+++ b/context.go
@@ -8,22 +8,28 @@ type executorKey struct {
 	name string
 }
 
-// HasExecutor returns true when the named executor is available in the context
-func HasExecutor(ctx context.Context, name string) bool {
+// HasContextExecutor returns true when the named executor is available in the context
+func HasContextExecutor(ctx context.Context, name string) bool {
 	return ctx.Value(executorKey{name: name}) != nil
 }
 
-// GetExecutor returns an executor in context with the given name, or a serial executor if none exists
-// and replaces the context with one that contains a new executor which won't deadlock
-func GetExecutor(ctx context.Context, name string) Executor {
-	executor, ok := ctx.Value(executorKey{name: name}).(Executor)
+// ContextExecutor returns an executor in context with the given name, or a serial executor if none exists
+// and replaces the context with one that contains a new executor which won't deadlock if the context
+func ContextExecutor(ctx *context.Context, name string) Executor {
+	if ctx == nil {
+		return serialExecutor{}
+	}
+	executor, ok := (*ctx).Value(executorKey{name: name}).(Executor)
 	if !ok || executor == nil {
-		return sequentialExecutor{}
+		return serialExecutor{}
+	}
+	if e, _ := executor.(ChildExecutor); e != nil {
+		*ctx = SetContextExecutor(*ctx, name, e.ChildExecutor())
 	}
 	return executor
 }
 
-// SetContextExecutor returns a context with the named provided executor for use with GetExecutor
-func SetContextExecutor(ctx context.Context, executor Executor) context.Context {
-	return context.WithValue(ctx, executorKey{name: executor.Name()}, executor)
+// SetContextExecutor returns a context with the named executor for use with GetExecutor
+func SetContextExecutor(ctx context.Context, name string, executor Executor) context.Context {
+	return context.WithValue(ctx, executorKey{name: name}, executor)
 }

--- a/context.go
+++ b/context.go
@@ -1,17 +1,23 @@
 package sync
 
-import "context"
+import (
+	"context"
+)
 
-type executorKey struct{}
+type ExecutorName string
 
-func ContextExecutor(ctx context.Context) Executor {
-	executor, ok := ctx.Value(executorKey{}).(Executor)
+type executorKey struct {
+	name ExecutorName
+}
+
+func ContextExecutor(ctx context.Context, name ExecutorName) Executor {
+	executor, ok := ctx.Value(executorKey{name: name}).(Executor)
 	if !ok {
 		return sequentialExecutor{}
 	}
 	return executor
 }
 
-func SetContextExecutor(ctx context.Context, executor Executor) context.Context {
-	return context.WithValue(ctx, executorKey{}, executor)
+func SetContextExecutor(ctx context.Context, name ExecutorName, executor Executor) context.Context {
+	return context.WithValue(ctx, executorKey{name: name}, executor)
 }

--- a/context.go
+++ b/context.go
@@ -10,7 +10,17 @@ type executorKey struct {
 	name ExecutorName
 }
 
-func ContextExecutor(ctx context.Context, name ExecutorName) Executor {
+// ContextExecutor returns an executor and a child context which prevents deadlock
+// in the case that child processes use the same bounded executor
+func ContextExecutor(ctx context.Context, name ExecutorName) (context.Context, Executor) {
+	executor := GetExecutor(ctx, name)
+	child := executor.ChildExecutor()
+	ctx = SetContextExecutor(ctx, name, child)
+	return ctx, executor
+}
+
+// GetExecutor returns an executor in context with the given name, or a serial executor if none exists
+func GetExecutor(ctx context.Context, name ExecutorName) Executor {
 	executor, ok := ctx.Value(executorKey{name: name}).(Executor)
 	if !ok {
 		return sequentialExecutor{}
@@ -18,6 +28,8 @@ func ContextExecutor(ctx context.Context, name ExecutorName) Executor {
 	return executor
 }
 
+// SetContextExecutor returns a context with the named provided executor for use with
+// GetExecutor and ContextExecutor
 func SetContextExecutor(ctx context.Context, name ExecutorName, executor Executor) context.Context {
 	return context.WithValue(ctx, executorKey{name: name}, executor)
 }

--- a/context.go
+++ b/context.go
@@ -16,7 +16,7 @@ func HasContextExecutor(ctx context.Context, name string) bool {
 // ContextExecutor returns an executor in context with the given name, or a serial executor if none exists
 // and replaces the context with one that contains a new executor which won't deadlock if the context
 func ContextExecutor(ctx *context.Context, name string) Executor {
-	if ctx == nil {
+	if ctx == nil || *ctx == nil {
 		return serialExecutor{}
 	}
 	executor, ok := (*ctx).Value(executorKey{name: name}).(Executor)
@@ -33,3 +33,6 @@ func ContextExecutor(ctx *context.Context, name string) Executor {
 func SetContextExecutor(ctx context.Context, name string, executor Executor) context.Context {
 	return context.WithValue(ctx, executorKey{name: name}, executor)
 }
+
+var emptyContext = context.TODO()
+var emptyContextPtr = &emptyContext

--- a/context.go
+++ b/context.go
@@ -14,7 +14,7 @@ func HasContextExecutor(ctx context.Context, name string) bool {
 }
 
 // ContextExecutor returns an executor in context with the given name, or a serial executor if none exists
-// and replaces the context with one that contains a new executor which won't deadlock if the context
+// and replaces the context with one that contains a new executor which won't deadlock
 func ContextExecutor(ctx *context.Context, name string) Executor {
 	if ctx == nil || *ctx == nil {
 		return serialExecutor{}

--- a/context.go
+++ b/context.go
@@ -15,26 +15,15 @@ func HasExecutor(ctx context.Context, name string) bool {
 
 // GetExecutor returns an executor in context with the given name, or a serial executor if none exists
 // and replaces the context with one that contains a new executor which won't deadlock
-func GetExecutor(ctx *context.Context, name string) Executor {
-	if ctx == nil {
-		return sequentialExecutor{}
-	}
-	executor := getExecutor(*ctx, name)
-	*ctx = SetContextExecutor(*ctx, name, executor.ChildExecutor())
-	return executor
-}
-
-// SetContextExecutor returns a context with the named provided executor for use with
-// GetExecutor and ContextExecutor
-func SetContextExecutor(ctx context.Context, name string, executor Executor) context.Context {
-	return context.WithValue(ctx, executorKey{name: name}, executor)
-}
-
-// getExecutor only returns the executor in context
-func getExecutor(ctx context.Context, name string) Executor {
+func GetExecutor(ctx context.Context, name string) Executor {
 	executor, ok := ctx.Value(executorKey{name: name}).(Executor)
-	if !ok {
+	if !ok || executor == nil {
 		return sequentialExecutor{}
 	}
 	return executor
+}
+
+// SetContextExecutor returns a context with the named provided executor for use with GetExecutor
+func SetContextExecutor(ctx context.Context, executor Executor) context.Context {
+	return context.WithValue(ctx, executorKey{name: executor.Name()}, executor)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -9,15 +9,15 @@ import (
 
 func Test_HasExecutor(t *testing.T) {
 	t.Run("WithExecutorInContext", func(t *testing.T) {
-		executor := NewExecutor(2)
-		ctx := SetContextExecutor(context.Background(), "cpu", executor)
+		executor := NewExecutor("cpu", 2)
+		ctx := SetContextExecutor(context.Background(), executor)
 
 		require.True(t, HasExecutor(ctx, "cpu"))
 	})
 
 	t.Run("WithOtherExecutorInContext", func(t *testing.T) {
-		executor := NewExecutor(2)
-		ctx := SetContextExecutor(context.Background(), "cpu", executor)
+		executor := NewExecutor("cpu", 2)
+		ctx := SetContextExecutor(context.Background(), executor)
 
 		require.False(t, HasExecutor(ctx, "io"))
 	})
@@ -25,10 +25,10 @@ func Test_HasExecutor(t *testing.T) {
 
 func Test_GetExecutor(t *testing.T) {
 	t.Run("WithExecutorInContext", func(t *testing.T) {
-		executor := NewExecutor(2)
-		ctx := SetContextExecutor(context.Background(), "cpu", executor)
+		executor := NewExecutor("cpu", 2)
+		ctx := SetContextExecutor(context.Background(), executor)
 
-		result := GetExecutor(&ctx, "cpu")
+		result := GetExecutor(ctx, "cpu")
 
 		require.NotNil(t, result)
 		require.IsType(t, &boundedExecutor{}, result)
@@ -37,17 +37,17 @@ func Test_GetExecutor(t *testing.T) {
 	t.Run("WithoutExecutorInContext", func(t *testing.T) {
 		ctx := context.Background()
 
-		result := GetExecutor(&ctx, "cpu")
+		result := GetExecutor(ctx, "cpu")
 
 		require.NotNil(t, result)
 		require.IsType(t, sequentialExecutor{}, result)
 	})
 
 	t.Run("WitDifferentExecutorInContext", func(t *testing.T) {
-		executor := NewExecutor(1)
-		ctx := SetContextExecutor(context.Background(), "cpu", executor)
+		executor := NewExecutor("cpu", 1)
+		ctx := SetContextExecutor(context.Background(), executor)
 
-		result := GetExecutor(&ctx, "io")
+		result := GetExecutor(ctx, "io")
 
 		require.NotNil(t, result)
 		require.IsType(t, sequentialExecutor{}, result)

--- a/context_test.go
+++ b/context_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestContextExecutor(t *testing.T) {
+func Test_GetExecutor(t *testing.T) {
 	t.Run("WithExecutorInContext", func(t *testing.T) {
 		executor := NewExecutor(2)
 		ctx := SetContextExecutor(context.Background(), "cpu", executor)
 
-		result := ContextExecutor(ctx, "cpu")
+		result := GetExecutor(ctx, "cpu")
 
 		require.NotNil(t, result)
 		require.IsType(t, &boundedExecutor{}, result)
@@ -21,7 +21,7 @@ func TestContextExecutor(t *testing.T) {
 	t.Run("WithoutExecutorInContext", func(t *testing.T) {
 		ctx := context.Background()
 
-		result := ContextExecutor(ctx, "cpu")
+		result := GetExecutor(ctx, "cpu")
 
 		require.NotNil(t, result)
 		require.IsType(t, sequentialExecutor{}, result)
@@ -31,7 +31,7 @@ func TestContextExecutor(t *testing.T) {
 		executor := NewExecutor(1)
 		ctx := SetContextExecutor(context.Background(), "cpu", executor)
 
-		result := ContextExecutor(ctx, "io")
+		result := GetExecutor(ctx, "io")
 
 		require.NotNil(t, result)
 		require.IsType(t, sequentialExecutor{}, result)

--- a/context_test.go
+++ b/context_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestContextExecutor(t *testing.T) {
 	t.Run("WithExecutorInContext", func(t *testing.T) {
-		executor := NewExecutor(1)
-		ctx := SetContextExecutor(context.Background(), executor)
+		executor := NewExecutor(2)
+		ctx := SetContextExecutor(context.Background(), "cpu", executor)
 
-		result := ContextExecutor(ctx)
+		result := ContextExecutor(ctx, "cpu")
 
 		require.NotNil(t, result)
 		require.IsType(t, &boundedExecutor{}, result)
@@ -21,7 +21,17 @@ func TestContextExecutor(t *testing.T) {
 	t.Run("WithoutExecutorInContext", func(t *testing.T) {
 		ctx := context.Background()
 
-		result := ContextExecutor(ctx)
+		result := ContextExecutor(ctx, "cpu")
+
+		require.NotNil(t, result)
+		require.IsType(t, sequentialExecutor{}, result)
+	})
+
+	t.Run("WitDifferentExecutorInContext", func(t *testing.T) {
+		executor := NewExecutor(1)
+		ctx := SetContextExecutor(context.Background(), "cpu", executor)
+
+		result := ContextExecutor(ctx, "io")
 
 		require.NotNil(t, result)
 		require.IsType(t, sequentialExecutor{}, result)

--- a/context_test.go
+++ b/context_test.go
@@ -7,12 +7,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_HasExecutor(t *testing.T) {
+	t.Run("WithExecutorInContext", func(t *testing.T) {
+		executor := NewExecutor(2)
+		ctx := SetContextExecutor(context.Background(), "cpu", executor)
+
+		require.True(t, HasExecutor(ctx, "cpu"))
+	})
+
+	t.Run("WithOtherExecutorInContext", func(t *testing.T) {
+		executor := NewExecutor(2)
+		ctx := SetContextExecutor(context.Background(), "cpu", executor)
+
+		require.False(t, HasExecutor(ctx, "io"))
+	})
+}
+
 func Test_GetExecutor(t *testing.T) {
 	t.Run("WithExecutorInContext", func(t *testing.T) {
 		executor := NewExecutor(2)
 		ctx := SetContextExecutor(context.Background(), "cpu", executor)
 
-		result := GetExecutor(ctx, "cpu")
+		result := GetExecutor(&ctx, "cpu")
 
 		require.NotNil(t, result)
 		require.IsType(t, &boundedExecutor{}, result)
@@ -21,7 +37,7 @@ func Test_GetExecutor(t *testing.T) {
 	t.Run("WithoutExecutorInContext", func(t *testing.T) {
 		ctx := context.Background()
 
-		result := GetExecutor(ctx, "cpu")
+		result := GetExecutor(&ctx, "cpu")
 
 		require.NotNil(t, result)
 		require.IsType(t, sequentialExecutor{}, result)
@@ -31,7 +47,7 @@ func Test_GetExecutor(t *testing.T) {
 		executor := NewExecutor(1)
 		ctx := SetContextExecutor(context.Background(), "cpu", executor)
 
-		result := GetExecutor(ctx, "io")
+		result := GetExecutor(&ctx, "io")
 
 		require.NotNil(t, result)
 		require.IsType(t, sequentialExecutor{}, result)

--- a/context_test.go
+++ b/context_test.go
@@ -40,7 +40,7 @@ func Test_ContextExecutor(t *testing.T) {
 		require.IsType(t, serialExecutor{}, result)
 	})
 
-	t.Run("WitDifferentExecutorInContext", func(t *testing.T) {
+	t.Run("WithDifferentExecutorInContext", func(t *testing.T) {
 		ctx := SetContextExecutor(context.Background(), "io", &unboundedExecutor{})
 
 		result := ContextExecutor(&ctx, "cpu")

--- a/context_test.go
+++ b/context_test.go
@@ -7,49 +7,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_HasExecutor(t *testing.T) {
+func Test_HasContextExecutor(t *testing.T) {
 	t.Run("WithExecutorInContext", func(t *testing.T) {
-		executor := NewExecutor("cpu", 2)
-		ctx := SetContextExecutor(context.Background(), executor)
+		ctx := SetContextExecutor(context.Background(), "cpu", &unboundedExecutor{})
 
-		require.True(t, HasExecutor(ctx, "cpu"))
+		require.True(t, HasContextExecutor(ctx, "cpu"))
 	})
 
 	t.Run("WithOtherExecutorInContext", func(t *testing.T) {
-		executor := NewExecutor("cpu", 2)
-		ctx := SetContextExecutor(context.Background(), executor)
+		ctx := SetContextExecutor(context.Background(), "cpu", &unboundedExecutor{})
 
-		require.False(t, HasExecutor(ctx, "io"))
+		require.False(t, HasContextExecutor(ctx, "io"))
 	})
 }
 
-func Test_GetExecutor(t *testing.T) {
+func Test_ContextExecutor(t *testing.T) {
 	t.Run("WithExecutorInContext", func(t *testing.T) {
-		executor := NewExecutor("cpu", 2)
-		ctx := SetContextExecutor(context.Background(), executor)
+		ctx := SetContextExecutor(context.Background(), "cpu", &unboundedExecutor{})
 
-		result := GetExecutor(ctx, "cpu")
+		result := ContextExecutor(&ctx, "cpu")
 
 		require.NotNil(t, result)
-		require.IsType(t, &boundedExecutor{}, result)
+		require.IsType(t, &unboundedExecutor{}, result)
 	})
 
 	t.Run("WithoutExecutorInContext", func(t *testing.T) {
 		ctx := context.Background()
 
-		result := GetExecutor(ctx, "cpu")
+		result := ContextExecutor(&ctx, "cpu")
 
 		require.NotNil(t, result)
-		require.IsType(t, sequentialExecutor{}, result)
+		require.IsType(t, serialExecutor{}, result)
 	})
 
 	t.Run("WitDifferentExecutorInContext", func(t *testing.T) {
-		executor := NewExecutor("cpu", 1)
-		ctx := SetContextExecutor(context.Background(), executor)
+		ctx := SetContextExecutor(context.Background(), "io", &unboundedExecutor{})
 
-		result := GetExecutor(ctx, "io")
+		result := ContextExecutor(&ctx, "cpu")
 
 		require.NotNil(t, result)
-		require.IsType(t, sequentialExecutor{}, result)
+		require.IsType(t, serialExecutor{}, result)
 	})
 }

--- a/executor.go
+++ b/executor.go
@@ -3,22 +3,24 @@ package sync
 import (
 	"context"
 	"math"
-	"sync"
-	"sync/atomic"
 )
 
 // Executor the executor interface allows for different strategies to execute units of work and wait for all units
 // of work to be completed
 type Executor interface {
-	// Name returns the executor's name, used to look it up in context
-	Name() string
-
 	// Execute adds a unit of work to be executed by the executor
-	Execute(context.Context, func(context.Context))
+	Execute(func())
 
-	// Wait blocks and waits for all the executing functions to be completed before returning, if more functions are
-	// added to be executed by this executor after the Wait call, these will also complete before Wait proceeds
-	Wait()
+	// Wait blocks and waits for all the executing functions to be completed before returning, or the context is cancelled.
+	// if more functions are added to be executed by this executor after the Wait call, these will also complete before Wait proceeds
+	// If the context is canceled, any queued functions will not be executed
+	Wait(context.Context)
+}
+
+// ChildExecutor interface, if implemented, will cause GetContextExecutor calls to replace the provided context
+// with a child executor returned from this function. This is used when it is not safe to nest Execute calls
+type ChildExecutor interface {
+	ChildExecutor() Executor
 }
 
 // NewExecutor returns an Executor based on the desired concurrency:
@@ -26,82 +28,20 @@ type Executor interface {
 //	< 0: unbounded, spawn a new goroutine for each Execute call
 //	  0: serial, executes in the same thread/routine as the caller of Execute
 //	> 0: a bounded executor with the maximum concurrency provided
-func NewExecutor(name string, maxConcurrency int) Executor {
+func NewExecutor(maxConcurrency int) Executor {
 	if maxConcurrency < 0 || maxConcurrency > math.MaxInt32 {
-		return &unboundedExecutor{
-			name: name,
-		}
+		return &unboundedExecutor{}
 	}
 	if maxConcurrency == 0 {
-		return sequentialExecutor{
-			name: name,
-		}
+		return serialExecutor{}
 	}
-	return &boundedExecutor{
-		name:          name,
-		maxConcurrent: int32(maxConcurrency),
+	if useErrGroup {
+		return newErrGroupExecutor(maxConcurrency)
 	}
+	e := &queuedExecutor{
+		maxConcurrency: maxConcurrency,
+	}
+	return e
 }
 
-type boundedExecutor struct {
-	name          string // name used in context
-	maxConcurrent int32
-	executing     atomic.Int32
-	queue         List[*func()]
-	wg            sync.WaitGroup
-	childLock     sync.Mutex
-	childExecutor *boundedExecutor
-}
-
-func (e *boundedExecutor) Name() string {
-	return e.name
-}
-
-func (e *boundedExecutor) Execute(ctx context.Context, f func(context.Context)) {
-	ctx = SetContextExecutor(ctx, e.getChildExecutor())
-	e.wg.Add(1)
-	fn := func() {
-		defer e.wg.Done()
-		f(ctx)
-	}
-	e.queue.Enqueue(&fn)
-	if e.executing.Load() < e.maxConcurrent {
-		e.executing.Add(1)
-		go e.exec()
-	}
-}
-
-func (e *boundedExecutor) Wait() {
-	e.wg.Wait()
-}
-
-func (e *boundedExecutor) exec() {
-	defer e.executing.Add(-1)
-	if e.executing.Load() > e.maxConcurrent {
-		return
-	}
-	for {
-		f, ok := e.queue.Dequeue()
-		if !ok {
-			return
-		}
-		if f != nil {
-			(*f)()
-		}
-	}
-}
-
-func (e *boundedExecutor) getChildExecutor() Executor {
-	e.childLock.Lock()
-	defer e.childLock.Unlock()
-	// create a child executor with the same bound
-	if e.childExecutor == nil {
-		e.childExecutor = &boundedExecutor{
-			name:          e.name,
-			maxConcurrent: e.maxConcurrent,
-		}
-	}
-	return e.childExecutor
-}
-
-var _ Executor = (*boundedExecutor)(nil)
+var useErrGroup = true

--- a/executor.go
+++ b/executor.go
@@ -10,11 +10,11 @@ import (
 // Executor the executor interface allows for different strategies to execute units of work and wait for all units
 // of work to be completed
 type Executor interface {
+	// Name returns the executor's name, used to look it up in context
+	Name() string
+
 	// Execute adds a unit of work to be executed by the executor
 	Execute(context.Context, func(context.Context))
-
-	// ChildExecutor returns an executor that is safe to be passed down within parallel calls to use as this executor
-	ChildExecutor() Executor
 
 	// Wait blocks and waits for all the executing functions to be completed before returning, if more functions are
 	// added to be executed by this executor after the Wait call, these will also complete before Wait proceeds
@@ -26,19 +26,25 @@ type Executor interface {
 //	< 0: unbounded, spawn a new goroutine for each Execute call
 //	  0: serial, executes in the same thread/routine as the caller of Execute
 //	> 0: a bounded executor with the maximum concurrency provided
-func NewExecutor(maxConcurrency int) Executor {
+func NewExecutor(name string, maxConcurrency int) Executor {
 	if maxConcurrency < 0 || maxConcurrency > math.MaxInt32 {
-		return &unboundedExecutor{}
+		return &unboundedExecutor{
+			name: name,
+		}
 	}
 	if maxConcurrency == 0 {
-		return sequentialExecutor{}
+		return sequentialExecutor{
+			name: name,
+		}
 	}
 	return &boundedExecutor{
+		name:          name,
 		maxConcurrent: int32(maxConcurrency),
 	}
 }
 
 type boundedExecutor struct {
+	name          string // name used in context
 	maxConcurrent int32
 	executing     atomic.Int32
 	queue         List[*func()]
@@ -47,21 +53,12 @@ type boundedExecutor struct {
 	childExecutor *boundedExecutor
 }
 
-func (e *boundedExecutor) ChildExecutor() Executor {
-	e.childLock.Lock()
-	defer e.childLock.Unlock()
-	// create a child executor with the same bound
-	if e.childExecutor == nil {
-		e.childExecutor = &boundedExecutor{
-			maxConcurrent: e.maxConcurrent,
-		}
-	}
-	return e.childExecutor
+func (e *boundedExecutor) Name() string {
+	return e.name
 }
 
-var _ Executor = (*boundedExecutor)(nil)
-
 func (e *boundedExecutor) Execute(ctx context.Context, f func(context.Context)) {
+	ctx = SetContextExecutor(ctx, e.getChildExecutor())
 	e.wg.Add(1)
 	fn := func() {
 		defer e.wg.Done()
@@ -93,3 +90,18 @@ func (e *boundedExecutor) exec() {
 		}
 	}
 }
+
+func (e *boundedExecutor) getChildExecutor() Executor {
+	e.childLock.Lock()
+	defer e.childLock.Unlock()
+	// create a child executor with the same bound
+	if e.childExecutor == nil {
+		e.childExecutor = &boundedExecutor{
+			name:          e.name,
+			maxConcurrent: e.maxConcurrent,
+		}
+	}
+	return e.childExecutor
+}
+
+var _ Executor = (*boundedExecutor)(nil)

--- a/executor.go
+++ b/executor.go
@@ -8,8 +8,9 @@ import (
 // Executor the executor interface allows for different strategies to execute units of work and wait for all units
 // of work to be completed
 type Executor interface {
-	// Execute adds a unit of work to be executed by the executor
-	Execute(func())
+	// Go adds a unit of work to be executed by the executor. Depending on the execution strategy this may be blocking
+	// or may execute the function directly
+	Go(func())
 
 	// Wait blocks and waits for all the executing functions to be completed before returning, or the context is cancelled.
 	// if more functions are added to be executed by this executor after the Wait call, these will also complete before Wait proceeds
@@ -18,15 +19,15 @@ type Executor interface {
 }
 
 // ChildExecutor interface, if implemented, will cause ContextExecutor calls to replace the provided context with one
-// containing a child executor returned from this function. This is used when it is not safe to nest Execute calls
+// containing a child executor returned from this function. This is used when it is not safe to nest Go calls
 type ChildExecutor interface {
 	ChildExecutor() Executor
 }
 
 // NewExecutor returns an Executor based on the desired concurrency:
 //
-//	< 0: unbounded, spawn a new goroutine for each Execute call
-//	  0: serial, executes in the same thread/routine as the caller of Execute
+//	< 0: unbounded, spawn a new goroutine for each Go call
+//	  0: serial, executes in the same thread/routine as the caller of Go
 //	> 0: a bounded executor with the maximum concurrency provided
 func NewExecutor(maxConcurrency int) Executor {
 	if maxConcurrency < 0 || maxConcurrency > math.MaxInt32 {
@@ -35,13 +36,5 @@ func NewExecutor(maxConcurrency int) Executor {
 	if maxConcurrency == 0 {
 		return serialExecutor{}
 	}
-	if useErrGroup {
-		return newErrGroupExecutor(maxConcurrency)
-	}
-	e := &queuedExecutor{
-		maxConcurrency: maxConcurrency,
-	}
-	return e
+	return newErrGroupExecutor(maxConcurrency)
 }
-
-var useErrGroup = true

--- a/executor.go
+++ b/executor.go
@@ -17,8 +17,8 @@ type Executor interface {
 	Wait(context.Context)
 }
 
-// ChildExecutor interface, if implemented, will cause GetContextExecutor calls to replace the provided context
-// with a child executor returned from this function. This is used when it is not safe to nest Execute calls
+// ChildExecutor interface, if implemented, will cause ContextExecutor calls to replace the provided context with one
+// containing a child executor returned from this function. This is used when it is not safe to nest Execute calls
 type ChildExecutor interface {
 	ChildExecutor() Executor
 }

--- a/executor.go
+++ b/executor.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
 )
@@ -22,7 +23,7 @@ type Executor interface {
 //	  0: serial, executes in the same thread/routine as the caller of Execute
 //	> 0: a bounded executor with the maximum concurrency provided
 func NewExecutor(maxConcurrency int) Executor {
-	if maxConcurrency < 0 {
+	if maxConcurrency < 0 || maxConcurrency > math.MaxInt32 {
 		return &unboundedExecutor{}
 	}
 	if maxConcurrency == 0 {

--- a/executor_errgroup.go
+++ b/executor_errgroup.go
@@ -27,7 +27,7 @@ func newErrGroupExecutor(maxConcurrency int) *errGroupExecutor {
 	return e
 }
 
-func (e *errGroupExecutor) Execute(f func()) {
+func (e *errGroupExecutor) Go(f func()) {
 	e.wg.Add(1)
 	fn := func() error {
 		defer e.wg.Done()

--- a/executor_errgroup.go
+++ b/executor_errgroup.go
@@ -1,0 +1,74 @@
+package sync
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type errGroupExecutor struct {
+	maxConcurrency int
+	canceled       atomic.Bool
+	g              errgroup.Group
+	wg             sync.WaitGroup
+	childLock      sync.RWMutex
+	childExecutor  *errGroupExecutor
+}
+
+func newErrGroupExecutor(maxConcurrency int) *errGroupExecutor {
+	e := &errGroupExecutor{
+		maxConcurrency: maxConcurrency,
+	}
+	e.g.SetLimit(maxConcurrency)
+	return e
+}
+
+func (e *errGroupExecutor) Execute(f func()) {
+	e.wg.Add(1)
+	fn := func() error {
+		defer e.wg.Done()
+		if e.canceled.Load() {
+			return nil
+		}
+		f()
+		return nil
+	}
+	e.g.Go(fn)
+}
+
+func (e *errGroupExecutor) Wait(ctx context.Context) {
+	e.canceled.Store(ctx.Err() != nil)
+
+	done := make(chan struct{}, 1)
+	go func() {
+		e.wg.Wait()
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		e.canceled.Store(true)
+
+	case <-done:
+	}
+}
+
+func (e *errGroupExecutor) ChildExecutor() Executor {
+	e.childLock.RLock()
+	defer e.childLock.RUnlock()
+	if e.childExecutor == nil {
+		e.childLock.RUnlock()
+		e.childLock.Lock() // exclusive lock so we only create one child executor
+		if e.childExecutor == nil {
+			// create a child executor with the same bound
+			e.childExecutor = newErrGroupExecutor(e.maxConcurrency)
+		}
+		e.childLock.Unlock()
+		e.childLock.RLock() // needed for defer to unlock
+	}
+	return e.childExecutor
+}
+
+var _ Executor = (*errGroupExecutor)(nil)

--- a/executor_errgroup.go
+++ b/executor_errgroup.go
@@ -8,8 +8,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// errGroupExecutor is an Executor that executes units of work, blocking when Execute is called once the maxConcurrency
-// is reached, only continuing subsequent Execute calls when the nuber of executing functions drops below maxConcurrency
+// errGroupExecutor is an Executor that executes units of work, blocking when Go is called once the maxConcurrency
+// is reached, only continuing subsequent Go calls when the nuber of executing functions drops below maxConcurrency
 type errGroupExecutor struct {
 	maxConcurrency int
 	canceled       atomic.Bool

--- a/executor_errgroup.go
+++ b/executor_errgroup.go
@@ -41,10 +41,10 @@ func (e *errGroupExecutor) Execute(f func()) {
 func (e *errGroupExecutor) Wait(ctx context.Context) {
 	e.canceled.Store(ctx.Err() != nil)
 
-	done := make(chan struct{}, 1)
+	done := make(chan struct{})
 	go func() {
 		e.wg.Wait()
-		done <- struct{}{}
+		close(done)
 	}()
 
 	select {

--- a/executor_errgroup_test.go
+++ b/executor_errgroup_test.go
@@ -1,0 +1,154 @@
+package sync
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_errGroupExecutorRepeated(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		Test_errGroupExecutor(t)
+	}
+}
+
+func Test_errGroupExecutor(t *testing.T) {
+	// this test sets up specific wait groups to ensure that the maximum concurrency is honored
+	// by stepping through and holding specific locks while conditions are verified
+	e := errGroupExecutor{maxConcurrency: 2}
+	e.g.SetLimit(2)
+
+	wg1 := &sync.WaitGroup{}
+	wg1.Add(1)
+	wg2 := &sync.WaitGroup{}
+	wg2.Add(1)
+	wg3 := &sync.WaitGroup{}
+	wg3.Add(1)
+
+	order := List[string]{}
+	executed := ""
+
+	wgReady := &sync.WaitGroup{}
+	wgReady.Add(2)
+
+	e.Execute(func() {
+		order.Append("pre wg1")
+		wgReady.Done()
+		wg1.Wait()
+		order.Append("post wg1")
+		executed += "1_"
+		wg3.Done()
+	})
+
+	e.Execute(func() {
+		order.Append("pre wg2")
+		wgReady.Done()
+		wg2.Wait()
+		order.Append("post wg2")
+		executed += "2_"
+	})
+
+	wgReady.Wait()
+
+	// errgroup execution is blocking, so the next e.Execute will block, so continue on the first before we deadlock
+	wg1.Done()
+
+	e.Execute(func() {
+		order.Append("pre wg3")
+		wg3.Wait()
+		order.Append("post wg3")
+		executed += "3_"
+		wg2.Done()
+	})
+
+	e.Wait(context.Background())
+	require.Equal(t, "1_3_2_", executed)
+	require.True(t,
+		order.indexOf("post wg1") < order.indexOf("post wg3") &&
+			order.indexOf("post wg3") < order.indexOf("post wg2"),
+	)
+}
+
+func Test_errGroupExecutorCancelRepeat(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		Test_errGroupExecutorCancel(t)
+	}
+}
+
+func Test_errGroupExecutorCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	e := &errGroupExecutor{}
+	e.g.SetLimit(2)
+
+	wgs := [3]sync.WaitGroup{}
+	wns := [3]sync.WaitGroup{}
+	for i := range wgs {
+		wns[i].Add(1)
+		wgs[i].Add(1)
+	}
+
+	executed := [3]bool{}
+	e.Execute(func() {
+		t.Logf("waiting 0")
+		wns[0].Done()
+		wgs[0].Wait()
+		t.Logf("done 0")
+		executed[0] = true
+	})
+	e.Execute(func() {
+		t.Logf("waiting 1")
+		wns[1].Done()
+		wgs[1].Wait()
+		t.Logf("done 1")
+		executed[1] = true
+	})
+
+	go func() {
+		wns[0].Wait()
+		wns[1].Wait()
+
+		// 0 and 1 are currently executing, waiting
+		cancel()
+
+		wns[2].Wait()
+
+		e.Execute(func() {
+			t.Logf("waiting 2")
+			wgs[2].Wait()
+			t.Logf("done 2")
+			executed[2] = true
+		})
+
+		for i := range wgs {
+			wgs[i].Done()
+		}
+
+	}()
+
+	// should be waiting in 0, 1 not executed 2
+	e.Wait(ctx)
+
+	wns[2].Done()
+
+	// should not have executed 2
+	require.False(t, executed[2])
+}
+
+func Test_errGroupExecutorSubcontext(t *testing.T) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	ctx := context.TODO()
+	ctx = SetContextExecutor(ctx, "", newErrGroupExecutor(1))
+	ContextExecutor(&ctx, "").Execute(func() {
+		// context should be replaced with a secondary executor
+		ContextExecutor(&ctx, "").Execute(func() {
+			// context should be replaced again with a tertiary executor
+			ContextExecutor(&ctx, "").Execute(func() {
+				wg.Done()
+			})
+		})
+	})
+	wg.Wait() // only done by sub-executor
+}

--- a/executor_errgroup_test.go
+++ b/executor_errgroup_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func Test_errGroupExecutorRepeated(t *testing.T) {
+	// iterating these tests many times tends to make problems apparent much more quickly,
+	// when they may succeed under certain conditions
 	for i := 0; i < 1000; i++ {
 		Test_errGroupExecutor(t)
 	}

--- a/executor_queue.go
+++ b/executor_queue.go
@@ -19,7 +19,7 @@ type queuedExecutor struct {
 
 var _ Executor = (*queuedExecutor)(nil)
 
-func (e *queuedExecutor) Execute(f func()) {
+func (e *queuedExecutor) Go(f func()) {
 	if e.canceled.Load() {
 		return
 	}

--- a/executor_queue.go
+++ b/executor_queue.go
@@ -39,16 +39,15 @@ func (e *queuedExecutor) Execute(f func()) {
 func (e *queuedExecutor) Wait(ctx context.Context) {
 	e.canceled.Store(ctx.Err() != nil)
 
-	done := make(chan struct{}, 1)
+	done := make(chan struct{})
 	go func() {
 		e.wg.Wait()
-		done <- struct{}{}
+		close(done)
 	}()
 
 	select {
 	case <-ctx.Done():
 		e.canceled.Store(true)
-
 	case <-done:
 	}
 }

--- a/executor_queue.go
+++ b/executor_queue.go
@@ -1,0 +1,69 @@
+package sync
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+type queuedExecutor struct {
+	canceled       atomic.Bool
+	maxConcurrency int
+	executing      atomic.Int32
+	queue          List[*func()]
+	wg             sync.WaitGroup
+}
+
+var _ Executor = (*queuedExecutor)(nil)
+
+func (e *queuedExecutor) Execute(f func()) {
+	if e.canceled.Load() {
+		return
+	}
+	e.wg.Add(1)
+	fn := func() {
+		defer e.wg.Done()
+		if e.canceled.Load() {
+			return
+		}
+		f()
+	}
+	e.queue.Enqueue(&fn)
+	if int(e.executing.Load()) < e.maxConcurrency {
+		go e.exec()
+	}
+}
+
+func (e *queuedExecutor) Wait(ctx context.Context) {
+	e.canceled.Store(ctx.Err() != nil)
+
+	done := make(chan struct{}, 1)
+	go func() {
+		e.wg.Wait()
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		e.canceled.Store(true)
+
+	case <-done:
+	}
+}
+
+func (e *queuedExecutor) exec() {
+	e.executing.Add(1)
+	defer e.executing.Add(-1)
+	if int(e.executing.Load()) > e.maxConcurrency {
+		return
+	}
+	for {
+		f, ok := e.queue.Dequeue()
+		if !ok {
+			return
+		}
+		if f != nil {
+			(*f)()
+		}
+	}
+}

--- a/executor_queue_test.go
+++ b/executor_queue_test.go
@@ -151,7 +151,9 @@ func Test_explicitExecutorLimiting(t *testing.T) {
 }
 
 func Test_queuedExecutorCancelRepeat(t *testing.T) {
-	for i := 0; i < 100; i++ {
+	// iterating these tests many times tends to make problems apparent much more quickly,
+	// when they may succeed under certain conditions
+	for i := 0; i < 1000; i++ {
 		Test_queuedExecutorCancel(t)
 	}
 }

--- a/executor_queue_test.go
+++ b/executor_queue_test.go
@@ -1,0 +1,226 @@
+package sync
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/go-sync/internal/atomic"
+	"github.com/anchore/go-sync/internal/stats"
+)
+
+func Test_queuedExecutor(t *testing.T) {
+	concurrency := 25
+	count := 1000
+
+	wgs := make([]sync.WaitGroup, count)
+
+	concurrent := stats.Tracked[int64]{}
+	total := atomic.Uint64{}
+
+	makeFunc := func(idx int) func() {
+		wgs[idx].Add(1)
+		return func() {
+			defer total.Add(1)
+			concurrent.Incr()
+			wgs[idx].Wait()
+			concurrent.Decr()
+		}
+	}
+
+	var expected []int
+
+	e := &queuedExecutor{maxConcurrency: concurrency}
+
+	for i := 0; i < count; i++ {
+		expected = append(expected, i)
+		e.Execute(makeFunc(i))
+	}
+
+	go func() {
+		for i := 0; i < count; i++ {
+			wgs[i].Done()
+		}
+	}()
+
+	e.Wait(context.Background())
+	require.LessOrEqual(t, concurrent.Max(), int64(concurrency))
+	require.Equal(t, total.Load(), uint64(count))
+}
+
+func Test_queuedExecutorSmall(t *testing.T) {
+	concurrency := 2
+	count := 4
+
+	wgs := make([]sync.WaitGroup, count)
+	waiting := sync.WaitGroup{}
+	waiting.Add(int(concurrency))
+
+	concurrent := stats.Tracked[int]{}
+	total := atomic.Uint64{}
+
+	makeFunc := func(idx int) func() {
+		wgs[idx].Add(1)
+		return func() {
+			if idx < int(concurrency) {
+				waiting.Done()
+			}
+			defer total.Add(1)
+			concurrent.Incr()
+			wgs[idx].Wait()
+			concurrent.Decr()
+		}
+	}
+
+	e := &queuedExecutor{maxConcurrency: concurrency}
+	for i := 0; i < count; i++ {
+		e.Execute(makeFunc(i))
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	waiting.Wait()
+	require.Equal(t, 2, concurrent.Val())
+
+	go func() {
+		for i := 0; i < count; i++ {
+			wgs[i].Done()
+		}
+	}()
+
+	e.Wait(context.Background())
+	require.LessOrEqual(t, concurrent.Max(), concurrency)
+	require.Equal(t, total.Load(), uint64(count))
+}
+
+func Test_explicitExecutorLimiting(t *testing.T) {
+	// this test sets up specific wait groups to ensure that the maximum concurrency is honored
+	// by stepping through and holding specific locks while conditions are verified
+	e := queuedExecutor{maxConcurrency: 2}
+
+	wg1 := &sync.WaitGroup{}
+	wg1.Add(1)
+	wg2 := &sync.WaitGroup{}
+	wg2.Add(1)
+	wg3 := &sync.WaitGroup{}
+	wg3.Add(1)
+
+	order := List[string]{}
+	executed := ""
+
+	wgReady := &sync.WaitGroup{}
+	wgReady.Add(2)
+
+	e.Execute(func() {
+		order.Append("pre wg1")
+		wgReady.Done()
+		wg1.Wait()
+		order.Append("post wg1")
+		executed += "1_"
+	})
+
+	e.Execute(func() {
+		order.Append("pre wg2")
+		wgReady.Done()
+		wg2.Wait()
+		order.Append("post wg2")
+		executed += "2_"
+		wg3.Done()
+	})
+
+	wgReady.Wait()
+
+	e.Execute(func() {
+		order.Append("pre wg3")
+		wg3.Wait()
+		order.Append("post wg3")
+		executed += "3_"
+		wg1.Done()
+	})
+
+	wg2.Done()
+
+	e.Wait(context.Background())
+	require.Equal(t, "2_3_1_", executed)
+	require.True(t,
+		order.indexOf("post wg2") < order.indexOf("post wg3") &&
+			order.indexOf("post wg3") < order.indexOf("post wg1"),
+	)
+}
+
+func Test_queuedExecutorCancelRepeat(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		Test_queuedExecutorCancel(t)
+	}
+}
+
+func Test_queuedExecutorCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	e := &queuedExecutor{maxConcurrency: 2}
+
+	wgs := [3]sync.WaitGroup{}
+	wns := [3]sync.WaitGroup{}
+	for i := range wgs {
+		wns[i].Add(1)
+		wgs[i].Add(1)
+	}
+
+	executed := [3]bool{}
+	e.Execute(func() {
+		wns[0].Done()
+		wgs[0].Wait()
+		executed[0] = true
+	})
+	e.Execute(func() {
+		wns[1].Done()
+		wgs[1].Wait()
+		executed[1] = true
+	})
+
+	go func() {
+		wns[0].Wait()
+		wns[1].Wait()
+
+		// 0 and 1 are currently executing, waiting
+		cancel()
+
+		wns[2].Wait()
+
+		e.Execute(func() {
+			wgs[2].Wait()
+			executed[2] = true
+		})
+
+		for i := range wgs {
+			wgs[i].Done()
+		}
+
+	}()
+
+	// should be waiting in 0, 1 not executed 2
+	e.Wait(ctx)
+
+	wns[2].Done()
+
+	// should not have executed 2
+	require.False(t, executed[2])
+}
+
+func Test_queuedExecutorSubcontext(t *testing.T) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	ctx := context.TODO()
+	ctx = SetContextExecutor(ctx, "", &queuedExecutor{maxConcurrency: 1})
+	ContextExecutor(&ctx, "").Execute(func() {
+		// context should be replaced with a secondary executor
+		ContextExecutor(&ctx, "").Execute(func() {
+			// context should be replaced again with a tertiary executor
+			ContextExecutor(&ctx, "").Execute(func() {
+				wg.Done()
+			})
+		})
+	})
+	wg.Wait() // only done by sub-executor
+}

--- a/executor_serial.go
+++ b/executor_serial.go
@@ -2,7 +2,13 @@ package sync
 
 import "context"
 
-type sequentialExecutor struct{}
+type sequentialExecutor struct {
+	name string
+}
+
+func (u sequentialExecutor) Name() string {
+	return u.name
+}
 
 func (u sequentialExecutor) ChildExecutor() Executor {
 	return u // safe for all children to use this executor

--- a/executor_serial.go
+++ b/executor_serial.go
@@ -2,18 +2,13 @@ package sync
 
 import "context"
 
-type sequentialExecutor struct {
-	name string
+type serialExecutor struct{}
+
+func (u serialExecutor) Execute(fn func()) {
+	fn()
 }
 
-func (u sequentialExecutor) Name() string {
-	return u.name
+func (u serialExecutor) Wait(_ context.Context) {
 }
 
-func (u sequentialExecutor) Execute(ctx context.Context, fn func(context.Context)) {
-	fn(ctx)
-}
-
-func (u sequentialExecutor) Wait() {}
-
-var _ Executor = (*sequentialExecutor)(nil)
+var _ Executor = (*serialExecutor)(nil)

--- a/executor_serial.go
+++ b/executor_serial.go
@@ -5,7 +5,7 @@ import "context"
 // serialExecutor is an Executor that executes serially, without any goroutines
 type serialExecutor struct{}
 
-func (u serialExecutor) Execute(fn func()) {
+func (u serialExecutor) Go(fn func()) {
 	fn()
 }
 

--- a/executor_serial.go
+++ b/executor_serial.go
@@ -10,10 +10,6 @@ func (u sequentialExecutor) Name() string {
 	return u.name
 }
 
-func (u sequentialExecutor) ChildExecutor() Executor {
-	return u // safe for all children to use this executor
-}
-
 func (u sequentialExecutor) Execute(ctx context.Context, fn func(context.Context)) {
 	fn(ctx)
 }

--- a/executor_serial.go
+++ b/executor_serial.go
@@ -2,6 +2,10 @@ package sync
 
 type sequentialExecutor struct{}
 
+func (u sequentialExecutor) ChildExecutor() Executor {
+	return u // safe for all children to use this executor
+}
+
 func (u sequentialExecutor) Execute(fn func()) {
 	fn()
 }

--- a/executor_serial.go
+++ b/executor_serial.go
@@ -2,6 +2,7 @@ package sync
 
 import "context"
 
+// serialExecutor is an Executor that executes serially, without any goroutines
 type serialExecutor struct{}
 
 func (u serialExecutor) Execute(fn func()) {

--- a/executor_serial.go
+++ b/executor_serial.go
@@ -1,13 +1,15 @@
 package sync
 
+import "context"
+
 type sequentialExecutor struct{}
 
 func (u sequentialExecutor) ChildExecutor() Executor {
 	return u // safe for all children to use this executor
 }
 
-func (u sequentialExecutor) Execute(fn func()) {
-	fn()
+func (u sequentialExecutor) Execute(ctx context.Context, fn func(context.Context)) {
+	fn(ctx)
 }
 
 func (u sequentialExecutor) Wait() {}

--- a/executor_serial_test.go
+++ b/executor_serial_test.go
@@ -11,11 +11,11 @@ func Test_serialSubcontext(t *testing.T) {
 	wg.Add(1)
 	ctx := context.TODO()
 	ctx = SetContextExecutor(ctx, "", serialExecutor{})
-	ContextExecutor(&ctx, "").Execute(func() {
+	ContextExecutor(&ctx, "").Go(func() {
 		// context should be able to continue
-		ContextExecutor(&ctx, "").Execute(func() {
+		ContextExecutor(&ctx, "").Go(func() {
 			// context should be able to continue
-			ContextExecutor(&ctx, "").Execute(func() {
+			ContextExecutor(&ctx, "").Go(func() {
 				wg.Done()
 			})
 		})

--- a/executor_serial_test.go
+++ b/executor_serial_test.go
@@ -1,0 +1,24 @@
+package sync
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func Test_serialSubcontext(t *testing.T) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	ctx := context.TODO()
+	ctx = SetContextExecutor(ctx, "", serialExecutor{})
+	ContextExecutor(&ctx, "").Execute(func() {
+		// context should be able to continue
+		ContextExecutor(&ctx, "").Execute(func() {
+			// context should be able to continue
+			ContextExecutor(&ctx, "").Execute(func() {
+				wg.Done()
+			})
+		})
+	})
+	wg.Wait() // only done by sub-executor
+}

--- a/executor_test.go
+++ b/executor_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -66,4 +67,141 @@ func Test_Executor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_Executor2(t *testing.T) {
+	concurrency := 25
+	count := 1000
+
+	wgs := make([]sync.WaitGroup, count)
+
+	concurrent := stats.Tracked[int64]{}
+	total := atomic.Uint64{}
+
+	makeFunc := func(idx int) func() {
+		wgs[idx].Add(1)
+		return func() {
+			defer total.Add(1)
+			concurrent.Incr()
+			wgs[idx].Wait()
+			concurrent.Decr()
+		}
+	}
+
+	var expected []int
+
+	e := NewExecutor(concurrency)
+	for i := 0; i < count; i++ {
+		expected = append(expected, i)
+		e.Execute(makeFunc(i))
+	}
+
+	go func() {
+		for i := 0; i < count; i++ {
+			wgs[i].Done()
+		}
+	}()
+
+	e.Wait()
+	require.LessOrEqual(t, concurrent.Max(), int64(concurrency))
+	require.Equal(t, total.Load(), uint64(count))
+}
+
+func Test_executorSmall(t *testing.T) {
+	concurrency := 2
+	count := 4
+
+	wgs := make([]sync.WaitGroup, count)
+	waiting := sync.WaitGroup{}
+	waiting.Add(int(concurrency))
+
+	concurrent := stats.Tracked[int]{}
+	total := atomic.Uint64{}
+
+	makeFunc := func(idx int) func() {
+		wgs[idx].Add(1)
+		return func() {
+			if idx < int(concurrency) {
+				waiting.Done()
+			}
+			defer total.Add(1)
+			concurrent.Incr()
+			wgs[idx].Wait()
+			concurrent.Decr()
+		}
+	}
+
+	e := NewExecutor(concurrency)
+	for i := 0; i < count; i++ {
+		e.Execute(makeFunc(i))
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	waiting.Wait()
+	require.Equal(t, 2, concurrent.Val())
+
+	go func() {
+		for i := 0; i < count; i++ {
+			wgs[i].Done()
+		}
+	}()
+
+	e.Wait()
+	require.LessOrEqual(t, concurrent.Max(), concurrency)
+	require.Equal(t, total.Load(), uint64(count))
+}
+
+func Test_explicitExecutorLimiting(t *testing.T) {
+	// this test sets up specific wait groups to ensure that the maximum concurrency is honored
+	// by stepping through and holding specific locks while conditions are verified
+	e := NewExecutor(2)
+
+	wg1 := &sync.WaitGroup{}
+	wg1.Add(1)
+	wg2 := &sync.WaitGroup{}
+	wg2.Add(1)
+	wg3 := &sync.WaitGroup{}
+	wg3.Add(1)
+
+	order := List[string]{}
+	executed := ""
+
+	wgReady := &sync.WaitGroup{}
+	wgReady.Add(2)
+
+	e.Execute(func() {
+		order.Append("pre wg1")
+		wgReady.Done()
+		wg1.Wait()
+		order.Append("post wg1")
+		executed += "1_"
+	})
+
+	e.Execute(func() {
+		order.Append("pre wg2")
+		wgReady.Done()
+		wg2.Wait()
+		order.Append("post wg2")
+		executed += "2_"
+		wg3.Done()
+	})
+
+	wgReady.Wait()
+
+	e.Execute(func() {
+		order.Append("pre wg3")
+		wg3.Wait()
+		order.Append("post wg3")
+		executed += "3_"
+		wg1.Done()
+	})
+
+	wg2.Done()
+
+	e.Wait()
+	require.Equal(t, "2_3_1_", executed)
+	require.True(t,
+		order.indexOf("post wg2") < order.indexOf("post wg3") &&
+			order.indexOf("post wg3") < order.indexOf("post wg1"),
+	)
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -45,7 +45,7 @@ func Test_Executor(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			e := NewExecutor(test.maxConcurrency)
+			e := NewExecutor("", test.maxConcurrency)
 
 			executed := atomic.Int32{}
 			concurrency := stats.Tracked[int]{}
@@ -91,7 +91,7 @@ func Test_Executor2(t *testing.T) {
 
 	var expected []int
 
-	e := NewExecutor(concurrency)
+	e := NewExecutor("", concurrency)
 	for i := 0; i < count; i++ {
 		expected = append(expected, i)
 		e.Execute(context.TODO(), makeFunc(i))
@@ -132,7 +132,7 @@ func Test_executorSmall(t *testing.T) {
 		}
 	}
 
-	e := NewExecutor(concurrency)
+	e := NewExecutor("", concurrency)
 	for i := 0; i < count; i++ {
 		e.Execute(context.TODO(), makeFunc(i))
 	}
@@ -155,7 +155,7 @@ func Test_executorSmall(t *testing.T) {
 func Test_explicitExecutorLimiting(t *testing.T) {
 	// this test sets up specific wait groups to ensure that the maximum concurrency is honored
 	// by stepping through and holding specific locks while conditions are verified
-	e := NewExecutor(2)
+	e := NewExecutor("", 2)
 
 	wg1 := &sync.WaitGroup{}
 	wg1.Add(1)

--- a/executor_unbounded.go
+++ b/executor_unbounded.go
@@ -8,6 +8,10 @@ type unboundedExecutor struct {
 	wg sync.WaitGroup
 }
 
+func (u *unboundedExecutor) ChildExecutor() Executor {
+	return u // safe for all children to use this executor
+}
+
 func (u *unboundedExecutor) Execute(f func()) {
 	u.wg.Add(1)
 	go func() {

--- a/executor_unbounded.go
+++ b/executor_unbounded.go
@@ -25,10 +25,10 @@ func (e *unboundedExecutor) Execute(f func()) {
 func (e *unboundedExecutor) Wait(ctx context.Context) {
 	e.canceled.Store(ctx.Err() != nil)
 
-	done := make(chan struct{}, 1)
+	done := make(chan struct{})
 	go func() {
 		e.wg.Wait()
-		done <- struct{}{}
+		close(done)
 	}()
 
 	select {

--- a/executor_unbounded.go
+++ b/executor_unbounded.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 )
 
-// unboundedExecutor executes all Execute calls without any specific bound
+// unboundedExecutor executes all Go calls without any specific bound
 type unboundedExecutor struct {
 	canceled atomic.Bool
 	wg       sync.WaitGroup

--- a/executor_unbounded.go
+++ b/executor_unbounded.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"sync"
 )
 
@@ -12,11 +13,11 @@ func (u *unboundedExecutor) ChildExecutor() Executor {
 	return u // safe for all children to use this executor
 }
 
-func (u *unboundedExecutor) Execute(f func()) {
+func (u *unboundedExecutor) Execute(ctx context.Context, f func(context.Context)) {
 	u.wg.Add(1)
 	go func() {
 		defer u.wg.Done()
-		f()
+		f(ctx)
 	}()
 }
 

--- a/executor_unbounded.go
+++ b/executor_unbounded.go
@@ -12,7 +12,7 @@ type unboundedExecutor struct {
 	wg       sync.WaitGroup
 }
 
-func (e *unboundedExecutor) Execute(f func()) {
+func (e *unboundedExecutor) Go(f func()) {
 	e.wg.Add(1)
 	go func() {
 		defer e.wg.Done()

--- a/executor_unbounded.go
+++ b/executor_unbounded.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 )
 
+// unboundedExecutor executes all Execute calls without any specific bound
 type unboundedExecutor struct {
 	canceled atomic.Bool
 	wg       sync.WaitGroup

--- a/executor_unbounded.go
+++ b/executor_unbounded.go
@@ -6,11 +6,12 @@ import (
 )
 
 type unboundedExecutor struct {
-	wg sync.WaitGroup
+	name string
+	wg   sync.WaitGroup
 }
 
-func (u *unboundedExecutor) ChildExecutor() Executor {
-	return u // safe for all children to use this executor
+func (u *unboundedExecutor) Name() string {
+	return u.name
 }
 
 func (u *unboundedExecutor) Execute(ctx context.Context, f func(context.Context)) {

--- a/executor_unbounded_test.go
+++ b/executor_unbounded_test.go
@@ -1,0 +1,24 @@
+package sync
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func Test_unboundedSubcontext(t *testing.T) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	ctx := context.TODO()
+	ctx = SetContextExecutor(ctx, "", &unboundedExecutor{})
+	ContextExecutor(&ctx, "").Execute(func() {
+		// context should be able to continue
+		ContextExecutor(&ctx, "").Execute(func() {
+			// context should be able to continue
+			ContextExecutor(&ctx, "").Execute(func() {
+				wg.Done()
+			})
+		})
+	})
+	wg.Wait() // only done by sub-executor
+}

--- a/executor_unbounded_test.go
+++ b/executor_unbounded_test.go
@@ -11,11 +11,11 @@ func Test_unboundedSubcontext(t *testing.T) {
 	wg.Add(1)
 	ctx := context.TODO()
 	ctx = SetContextExecutor(ctx, "", &unboundedExecutor{})
-	ContextExecutor(&ctx, "").Execute(func() {
+	ContextExecutor(&ctx, "").Go(func() {
 		// context should be able to continue
-		ContextExecutor(&ctx, "").Execute(func() {
+		ContextExecutor(&ctx, "").Go(func() {
 			// context should be able to continue
-			ContextExecutor(&ctx, "").Execute(func() {
+			ContextExecutor(&ctx, "").Go(func() {
 				wg.Done()
 			})
 		})

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/go-sync
 
-go 1.21.1
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/anchore/go-sync
 
 go 1.23.0
 
-require github.com/stretchr/testify v1.10.0
+require (
+	github.com/stretchr/testify v1.10.0
+	golang.org/x/sync v0.12.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,19 +1,25 @@
 package sync
 
-// Provider is the interface to use when returning a single item
+// Provider returns a single item
 type Provider[T any] interface {
 	Get() T
 }
 
-// Iterator is used when there are multiple values to be operated on
-type Iterator[T any] interface {
-	Each(fn func(value T))
+// Iterable provides a function to iterate a series of values
+type Iterable[T any] interface {
+	// Seq provides an iter.Seq compatible iterator
+	Seq(fn func(value T) bool)
+}
+
+// Appender to allow values to be appended
+type Appender[T any] interface {
+	Append(value T)
 }
 
 // Collection is a generic collection of values, which can be added to, removed from, and provide a length
 type Collection[T any] interface {
-	Iterator[T]
-	Add(value T)
+	Iterable[T]
+	Appender[T]
 	Remove(value T)
 	Contains(value T) bool
 	Len() int

--- a/internal/atomic/float64.go
+++ b/internal/atomic/float64.go
@@ -21,13 +21,13 @@ func (x *Float64) Store(val float64) {
 }
 
 // Swap atomically stores new into x and returns the previous value.
-func (x *Float64) Swap(new float64) (old float64) {
-	return math.Float64frombits(x.value.Swap(math.Float64bits(new)))
+func (x *Float64) Swap(newVal float64) (oldVal float64) {
+	return math.Float64frombits(x.value.Swap(math.Float64bits(newVal)))
 }
 
 // CompareAndSwap executes the compare-and-swap operation for x.
-func (x *Float64) CompareAndSwap(old, new float64) (swapped bool) {
-	return x.value.CompareAndSwap(math.Float64bits(old), math.Float64bits(new))
+func (x *Float64) CompareAndSwap(oldVal, newVal float64) (swapped bool) {
+	return x.value.CompareAndSwap(math.Float64bits(oldVal), math.Float64bits(newVal))
 }
 
 // Add atomically adds delta to x and returns the new value.

--- a/internal/channel/tee_test.go
+++ b/internal/channel/tee_test.go
@@ -26,7 +26,7 @@ func Test_ChannelTee(t *testing.T) {
 				case event, open := <-events:
 					if event != nil {
 						// t.Logf("%d: %v", number, event)
-						received.Add(number)
+						received.Append(number)
 						wg.Done()
 					}
 					if !open {
@@ -54,7 +54,7 @@ func Test_ChannelTee(t *testing.T) {
 	}()
 	wg.Wait()
 
-	require.ElementsMatch(t, collect(received), arr(1, 2, 3, 4, 5, 6, 7))
+	require.ElementsMatch(t, received.Values(), []int{1, 2, 3, 4, 5, 6, 7})
 
 	remove5()
 	received.Clear()
@@ -65,7 +65,7 @@ func Test_ChannelTee(t *testing.T) {
 	}()
 	wg.Wait()
 
-	require.ElementsMatch(t, collect(received), arr(1, 2, 3, 4, 6, 7))
+	require.ElementsMatch(t, received.Values(), []int{1, 2, 3, 4, 6, 7})
 
 	remove3()
 	received.Clear()
@@ -78,7 +78,7 @@ func Test_ChannelTee(t *testing.T) {
 
 	wg.Wait()
 
-	require.ElementsMatch(t, collect(received), arr(1, 2, 4, 6, 7))
+	require.ElementsMatch(t, received.Values(), []int{1, 2, 4, 6, 7})
 
 	remove7()
 	received.Clear()
@@ -90,22 +90,10 @@ func Test_ChannelTee(t *testing.T) {
 	}()
 
 	wg.Wait()
-	require.ElementsMatch(t, collect(received), arr(1, 2, 4, 6))
+	require.ElementsMatch(t, received.Values(), []int{1, 2, 4, 6})
 
 	closing.Store(true)
 	wg.Add(4)
 	close(events)
 	wg.Wait()
-}
-
-func collect(values gosync.Iterator[int]) []int {
-	var out []int
-	values.Each(func(value int) {
-		out = append(out, value)
-	})
-	return out
-}
-
-func arr[T any](values ...T) []T {
-	return values
 }

--- a/internal/stats/tracked.go
+++ b/internal/stats/tracked.go
@@ -124,7 +124,7 @@ func (t *TrackedFloat[T]) Avg() float64 {
 	return t.val.Load() / t.count.Load()
 }
 
-func (t *TrackedFloat[T]) OnMaxSet(f func(max T)) {
+func (t *TrackedFloat[T]) OnMaxSet(f func(T)) {
 	if t.maxSet != nil {
 		existing := t.maxSet
 		t.maxSet = func(val T) {

--- a/list_test.go
+++ b/list_test.go
@@ -15,26 +15,26 @@ func Test_List(t *testing.T) {
 	for _, e := range expected {
 		s.Push(e)
 	}
-	require.Equal(t, expected, collect(sl))
+	require.Equal(t, expected, sl.Values())
 	for i := range expected {
 		ev := len(expected) - 1 - i
 		exp := expected[:ev]
 		v, ok := s.Pop()
 		require.True(t, ok)
 		require.Equal(t, expected[ev], v)
-		require.Equal(t, exp, collect(sl))
+		require.Equal(t, exp, sl.Values())
 	}
 
 	// as a List:
 	ls := &List[int]{}
 	for _, v := range expected {
-		ls.Add(v)
+		ls.Append(v)
 	}
-	require.Equal(t, expected, collect(ls))
+	require.Equal(t, expected, ls.Values())
 	for i, e := range expected {
 		exp := expected[i+1:]
 		ls.Remove(e)
-		require.Equal(t, exp, collect(ls))
+		require.Equal(t, exp, ls.Values())
 	}
 
 	// as a queue:
@@ -43,37 +43,29 @@ func Test_List(t *testing.T) {
 	for _, e := range expected {
 		q.Enqueue(e)
 	}
-	require.Equal(t, expected, collect(sl))
+	require.Equal(t, expected, sl.Values())
 	for i, e := range expected {
 		exp := expected[i+1:]
 		got, ok := q.Dequeue()
 		require.True(t, ok)
 		require.Equal(t, e, got)
-		require.Equal(t, exp, collect(sl))
+		require.Equal(t, exp, sl.Values())
 	}
 
 	// from the middle:
 	sl = &List[int]{}
 	for _, value := range expected {
-		sl.Add(value)
+		sl.Append(value)
 	}
-	require.Equal(t, expected, collect(sl))
+	require.Equal(t, expected, sl.Values())
 	sl.Remove(4)
-	require.Equal(t, []int{0, 1, 2, 3, 5}, collect(sl))
+	require.Equal(t, []int{0, 1, 2, 3, 5}, sl.Values())
 	sl.Remove(2)
-	require.Equal(t, []int{0, 1, 3, 5}, collect(sl))
+	require.Equal(t, []int{0, 1, 3, 5}, sl.Values())
 	sl.Remove(1)
-	require.Equal(t, []int{0, 3, 5}, collect(sl))
+	require.Equal(t, []int{0, 3, 5}, sl.Values())
 	sl.Remove(5)
-	require.Equal(t, []int{0, 3}, collect(sl))
+	require.Equal(t, []int{0, 3}, sl.Values())
 	sl.Remove(0)
-	require.Equal(t, []int{3}, collect(sl))
-}
-
-func collect(values Iterator[int]) (out []int) {
-	out = []int{} // require.Equal() tests will fail when returning nil, since the expected slices are never nil
-	values.Each(func(value int) {
-		out = append(out, value)
-	})
-	return out
+	require.Equal(t, []int{3}, sl.Values())
 }

--- a/parallel_writer.go
+++ b/parallel_writer.go
@@ -16,7 +16,7 @@ type parallelWriter struct {
 // ParallelWriter returns a writer that writes the contents of each write call in parallel
 // to all provided writers
 func ParallelWriter(ctx context.Context, executorName string, writers ...io.Writer) io.Writer {
-	executor := GetExecutor(ctx, executorName)
+	executor := ContextExecutor(&ctx, executorName)
 	return &parallelWriter{
 		ctx:      ctx,
 		executor: executor,
@@ -29,7 +29,7 @@ func (w *parallelWriter) Write(p []byte) (int, error) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(w.writers))
 	for _, writer := range w.writers {
-		w.executor.Execute(w.ctx, func(_ context.Context) {
+		w.executor.Execute(func() {
 			defer wg.Done()
 			_, err := writer.Write(p)
 			if err != nil {

--- a/parallel_writer.go
+++ b/parallel_writer.go
@@ -29,7 +29,7 @@ func (w *parallelWriter) Write(p []byte) (int, error) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(w.writers))
 	for _, writer := range w.writers {
-		w.executor.Execute(func() {
+		w.executor.Go(func() {
 			defer wg.Done()
 			_, err := writer.Write(p)
 			if err != nil {

--- a/parallel_writer.go
+++ b/parallel_writer.go
@@ -15,10 +15,10 @@ type parallelWriter struct {
 
 // ParallelWriter returns a writer that writes the contents of each write call in parallel
 // to all provided writers
-func ParallelWriter(ctx *context.Context, executorName string, writers ...io.Writer) io.Writer {
+func ParallelWriter(ctx context.Context, executorName string, writers ...io.Writer) io.Writer {
 	executor := GetExecutor(ctx, executorName)
 	return &parallelWriter{
-		ctx:      *ctx,
+		ctx:      ctx,
 		executor: executor,
 		writers:  writers,
 	}

--- a/parallel_writer.go
+++ b/parallel_writer.go
@@ -1,0 +1,41 @@
+package sync
+
+import (
+	"errors"
+	"io"
+	"sync"
+)
+
+type parallelWriter struct {
+	executor Executor
+	writers  []io.Writer
+}
+
+func ParallelWriter(executor Executor, writers ...io.Writer) io.Writer {
+	return &parallelWriter{
+		executor: executor,
+		writers:  writers,
+	}
+}
+
+func (w *parallelWriter) Write(p []byte) (int, error) {
+	errs := List[error]{}
+	wg := sync.WaitGroup{}
+	wg.Add(len(w.writers))
+	for _, writer := range w.writers {
+		w.executor.Execute(func() {
+			defer wg.Done()
+			_, err := writer.Write(p)
+			if err != nil {
+				errs.Append(err)
+			}
+		})
+	}
+	wg.Wait()
+	if errs.Len() > 0 {
+		return 0, errors.Join(errs.Values()...)
+	}
+	return len(p), nil
+}
+
+var _ io.Writer = (*parallelWriter)(nil)

--- a/parallel_writer_test.go
+++ b/parallel_writer_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"bytes"
+	"context"
 	"sync/atomic"
 	"testing"
 
@@ -75,7 +76,8 @@ func Test_ParallelWriter(t *testing.T) {
 
 			contents := "some complicated contents"
 
-			w := ParallelWriter(NewExecutor(test.maxConcurrency), w1, w2, w3)
+			ctx := SetContextExecutor(context.TODO(), "", NewExecutor(test.maxConcurrency))
+			w := ParallelWriter(&ctx, "", w1, w2, w3)
 
 			iterations := 0
 			for i := 0; i < len(contents); i += test.bufferSize {

--- a/parallel_writer_test.go
+++ b/parallel_writer_test.go
@@ -76,8 +76,8 @@ func Test_ParallelWriter(t *testing.T) {
 
 			contents := "some complicated contents"
 
-			ctx := SetContextExecutor(context.TODO(), "", NewExecutor(test.maxConcurrency))
-			w := ParallelWriter(&ctx, "", w1, w2, w3)
+			ctx := SetContextExecutor(context.TODO(), NewExecutor("", test.maxConcurrency))
+			w := ParallelWriter(ctx, "", w1, w2, w3)
 
 			iterations := 0
 			for i := 0; i < len(contents); i += test.bufferSize {

--- a/parallel_writer_test.go
+++ b/parallel_writer_test.go
@@ -1,0 +1,113 @@
+package sync
+
+import (
+	"bytes"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/go-sync/internal/stats"
+)
+
+func Test_ParallelWriter(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxConcurrency int
+		bufferSize     int
+	}{
+		{
+			name:           "unbounded concurrency",
+			maxConcurrency: 0,
+			bufferSize:     4,
+		},
+		{
+			name:           "single execution",
+			maxConcurrency: 1,
+			bufferSize:     100,
+		},
+		{
+			name:           "dual execution",
+			maxConcurrency: 2,
+			bufferSize:     4,
+		},
+		{
+			name:           "ten-x execution",
+			maxConcurrency: 10,
+			bufferSize:     4,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			executed := atomic.Int32{}
+			concurrency := stats.Tracked[int]{}
+
+			buf1 := &bytes.Buffer{}
+			w1 := funcWriter{
+				fn: func(contents []byte) (int, error) {
+					defer concurrency.Incr()()
+					executed.Add(1)
+					buf1.Write(contents)
+					return len(contents), nil
+				},
+			}
+
+			buf2 := &bytes.Buffer{}
+			w2 := funcWriter{
+				fn: func(contents []byte) (int, error) {
+					defer concurrency.Incr()()
+					executed.Add(1)
+					buf2.Write(contents)
+					return len(contents), nil
+				},
+			}
+
+			buf3 := &bytes.Buffer{}
+			w3 := funcWriter{
+				fn: func(contents []byte) (int, error) {
+					defer concurrency.Incr()()
+					executed.Add(1)
+					buf3.Write(contents)
+					return len(contents), nil
+				},
+			}
+
+			contents := "some complicated contents"
+
+			w := ParallelWriter(NewExecutor(test.maxConcurrency), w1, w2, w3)
+
+			iterations := 0
+			for i := 0; i < len(contents); i += test.bufferSize {
+				iterations++
+				end := i + test.bufferSize
+				if end > len(contents) {
+					end = len(contents)
+				}
+				buf := contents[i:end]
+				n, err := w.Write([]byte(buf))
+				require.NoError(t, err)
+				require.Equal(t, len(buf), n)
+			}
+
+			require.Equal(t, 3*iterations, int(executed.Load()))
+			if test.maxConcurrency > 0 {
+				require.LessOrEqual(t, concurrency.Max(), test.maxConcurrency)
+			} else {
+				require.GreaterOrEqual(t, concurrency.Max(), 1)
+			}
+
+			require.Equal(t, contents, buf1.String())
+			require.Equal(t, contents, buf2.String())
+			require.Equal(t, contents, buf3.String())
+		})
+	}
+}
+
+type funcWriter struct {
+	fn func([]byte) (int, error)
+}
+
+func (f funcWriter) Write(p []byte) (int, error) {
+	return f.fn(p)
+}

--- a/parallel_writer_test.go
+++ b/parallel_writer_test.go
@@ -76,7 +76,7 @@ func Test_ParallelWriter(t *testing.T) {
 
 			contents := "some complicated contents"
 
-			ctx := SetContextExecutor(context.TODO(), NewExecutor("", test.maxConcurrency))
+			ctx := SetContextExecutor(context.Background(), "", NewExecutor(test.maxConcurrency))
 			w := ParallelWriter(ctx, "", w1, w2, w3)
 
 			iterations := 0


### PR DESCRIPTION
This PR implements variants of a bounded parallel scatter-gather pattern, allowing easy usage by downstream consumers in common use cases where a number of inputs can be processed concurrently to get mapped to a number of outputs.

There are a lot of changes here. The main ones are:

* remove the `Collector`, which was fairly awkward to use in favor of having a parallel `Collect` function, which allows for concurrent scatter-gather behavior
* adds a `ParallelWriter`, which efficiently passes every `Write` call to multiple writers in parallel, without copying buffers  (each `Write` call waits until all receivers have completed before returning)
* adds an errgroup-based executor, which has different, blocking behavior that avoids queueing up thousands of functions
* adds cancel functionality to all executors
* additional cleanup and alignment with current Go, for example using `Seq` for `iter.Seq` compatible iterator functions and instead of `Add`, use `Append`

This is used in syft as part of this PR: https://github.com/anchore/syft/pull/3636