### PR TITLE
feat: default context executor

### DIFF
--- a/context.go
+++ b/context.go
@@ -4,6 +4,8 @@ import (
 	"context"
 )
 
+const ExecutorDefault = ""
+
 type executorKey struct {
 	name string
 }
@@ -21,6 +23,9 @@ func ContextExecutor(ctx *context.Context, name string) Executor {
 	}
 	executor, ok := (*ctx).Value(executorKey{name: name}).(Executor)
 	if !ok || executor == nil {
+		if name != ExecutorDefault {
+			return ContextExecutor(ctx, ExecutorDefault)
+		}
 		return serialExecutor{}
 	}
 	if e, _ := executor.(ChildExecutor); e != nil {


### PR DESCRIPTION
This PR adds a default executor lookup in context when a specifically named executor is not present, allowing for default parallelism behavior to be provided without needing to know specifically what keys a library may need.