### PR TITLE
chore(deps): restore Go version to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/go-sync
 
-go 1.26.2
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
Restores the go directive in go.mod to 1.25.0 (pre-#36). Bumped in #36 (merge dbc8c60b7db8b8a1246c8587536ba01a3773ea84).