### PR TITLE
Tighten workflow-level permissions and expand dependabot scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,7 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
+      - "/.github/actions/*"
     cooldown:
       default-days: 7
     schedule:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: "Release"
 
-permissions:
-  contents: read
+permissions: {}
 
 # there should never be two releases in progress at the same time
 concurrency:

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -6,8 +6,7 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
 
@@ -15,6 +14,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Static analysis"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       # setup checkout, go, go-make, binny, and cache go modules
       - uses: anchore/go-make/.github/actions/setup@383ef7852b8ae43a30f424896b52479186d2ea4d # v0.1.0
@@ -26,6 +27,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Unit tests"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       # setup checkout, go, go-make, binny, and cache go modules
       - uses: anchore/go-make/.github/actions/setup@383ef7852b8ae43a30f424896b52479186d2ea4d # v0.1.0


### PR DESCRIPTION
Moves top-level workflow permissions from `contents: read` to `{}` across all three workflow files, pushing `contents: read` down to the job level where it's actually needed. Also adds `/.github/actions/*` to the dependabot github-actions ecosystem directories list so local composite actions get version-tracked.

Changes:
- set `permissions: {}` at workflow level in release.yaml, validate-github-actions.yaml, and validations.yaml
- add job-level `permissions: { contents: read }` to Static-Analysis and Unit-Test jobs in validations.yaml
- add `/.github/actions/*` directory to dependabot github-actions ecosystem

Notes:
- release.yaml already had `contents: write` scoped to the release job, so no change needed there
- validate-github-actions.yaml already had job-level permissions on the zizmor job