### PR TITLE
release pipeline refactor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,4 @@
 # Dependabot configuration
-#
-# Grouping behavior (see inline comments for details):
-#   - Minor + patch updates: grouped into a single PR per ecosystem
-#   - Major version bumps: individual PR per dependency
-#   - Security updates: individual PR per dependency
-#
-# Note: "patch" refers to semver version bumps (1.2.3 -> 1.2.4), not security fixes.
-# Security updates are identified separately via GitHub's Advisory Database and
-# can be any version bump (patch, minor, or major) that fixes a known CVE.
 
 version: 2
 
@@ -25,14 +16,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-    groups:
-      go-minor-patch:
-        applies-to: version-updates  # security updates get individual PRs
-        patterns:
-          - "*"
-        update-types:  # major omitted, gets individual PRs
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "github-actions"
     directories:
@@ -46,11 +29,3 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-    groups:
-      actions-minor-patch:
-        applies-to: version-updates  # security updates get individual PRs
-        patterns:
-          - "*"
-        update-types:  # major omitted, gets individual PRs
-          - "minor"
-          - "patch"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,11 @@ on:
       version:
         description: tag the latest commit on main with the given version (prefixed with v)
         required: true
+      skip-checks:
+        description: skip the check-gate (release even if checks haven't passed on main)
+        type: boolean
+        default: false
+        required: false
 
 jobs:
   version-available:
@@ -23,7 +28,9 @@ jobs:
       version: ${{ github.event.inputs.version }}
 
   check-gate:
+    if: ${{ !inputs.skip-checks }}
     permissions:
+      contents: read # required for the reusable workflow to check out the repo
       checks: read # required for getting the status of specific check names
     uses: anchore/workflows/.github/workflows/check-gate.yaml@b0c30a80409130d329aaa356fd64a34d8c0b3375 # v0.7.2
     with:
@@ -34,6 +41,14 @@ jobs:
 
   release:
     needs: [check-gate, version-available]
+    # run even when check-gate is skipped, but never when version-available
+    # failed/was skipped, nor when check-gate failed or was cancelled. note:
+    # always() disables the implicit success() gate on ALL needs, so the
+    # version-available requirement must be re-asserted explicitly here.
+    if: >-
+      ${{ always()
+          && needs.version-available.result == 'success'
+          && !contains(fromJSON('["failure", "cancelled"]'), needs.check-gate.result) }}
     environment: release # contains secrets needed for release
     runs-on: ubuntu-24.04
     permissions:
@@ -50,6 +65,7 @@ jobs:
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+          # for pushing tags (does not inherit workflow permissions)
+          TAG_TOKEN: ${{ secrets.TAG_TOKEN }}
           RELEASE_VERSION: ${{ github.event.inputs.version }}
         run: make ci-release

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,1 @@
-rules:
-  unpinned-uses:
-    ignore:
-      # Allow unpinned uses of trusted internal anchore/workflows actions
-      - oss-project-board-add.yaml
-      - remove-awaiting-response-label.yaml
+rules: {}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -90,8 +90,15 @@ issues:
 
 formatters:
   enable:
+    - gci
     - gofmt
-    - goimports
+  settings:
+    gci:
+      # See https://golangci-lint.run/docs/formatters/configuration/#gci
+      sections:
+        - standard # Standard section: captures all standard packages.
+        - default  # Default section: contains all imports that could not be matched to another section type.
+        - prefix(github.com/anchore)
   exclusions:
     generated: lax
     paths:

--- a/.make/go.mod
+++ b/.make/go.mod
@@ -2,11 +2,11 @@ module local
 
 go 1.25.0
 
-require github.com/anchore/go-make v0.4.0
+require github.com/anchore/go-make v0.7.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
-	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/mod v0.37.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 )

--- a/.make/go.sum
+++ b/.make/go.sum
@@ -1,10 +1,10 @@
-github.com/anchore/go-make v0.4.0 h1:poFE4PXcHwvix2E8AhdM7YHZ15bMhZb+W02i3+qrP8M=
-github.com/anchore/go-make v0.4.0/go.mod h1:Nc/tkwQHW1d1Vi8+0rtS/vSrH6pxieaUQXLdrctn+8g=
+github.com/anchore/go-make v0.7.0 h1:qosSwNWV/SsLFc1pI0DlrCZ2BUSDcGDcSKM6HdlnT6c=
+github.com/anchore/go-make v0.7.0/go.mod h1:4M6TnArb5w693VyWsgr5dCWrk2BLNu/ed4JUcsrzS34=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
-golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
-golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
quick pass refactoring go-sync's release pipeline:

- release.yaml: swapped DEPLOY_KEY for TAG_TOKEN in the ci-release step (for pushing tags; doesn't inherit workflow permissions)
- added a skip-checks workflow_dispatch input and wired check-gate to be skippable via `if: ${{ !inputs.skip-checks }}`
- added the always()-based `if` on the release job so it runs when check-gate is skipped but still requires version-available to succeed
- added `contents: read` to the check-gate job permissions (it only had checks: read)
- bumped go-make to v0.7.0 in .make
- dropped dependabot grouping (go-minor-patch / actions-minor-patch) so updates come as individual PRs
- removed the unpinned-uses config from zizmor (now just `rules: {}`)
- swapped goimports for the native gci formatter in golangci-lint

no separate manual tag/push step existed, so nothing to remove there. `make format` produced no source import changes.